### PR TITLE
Use D array syntax in common.d

### DIFF
--- a/source/c/fuse/common.d
+++ b/source/c/fuse/common.d
@@ -63,7 +63,7 @@ extern (System) {
         /**
          * For future use.
          */
-        uint reserved[23];
+        uint[23] reserved;
     }
 
     static assert(fuse_file_info.sizeof == 64);


### PR DESCRIPTION
This is what happens when I attempt to run dub build:

```
$ dub build
Building dfuse 0.3.0+commit.4.g8daf1d4 configuration "dfuse", build type debug.
Running dmd...
source/c/fuse/common.d(66): Warning: instead of C-style syntax, use D-style
syntax 'uint[23] reserved'
FAIL
.dub/build/dfuse-debug-linux.posix-x86_64-dmd_2067-A256FE164CF95BECB8B4CFF2350349C5/
dfuse staticLibrary
Error executing command build:
dmd failed with exit code 1.
```

Following the compiler's suggestion to use the D-style syntax makes the warning
go away and the compiler actually produces the `libdfuse.a` file.

Version info:

```
$ uname -a
Linux lupus 3.19.3-3-ARCH #1 SMP PREEMPT Wed Apr 8 14:10:00 CEST 2015 x86_64 GNU/Linux

$ dub --version
DUB version 0.9.23, built on Apr  8 2015

$ dmd --version
DMD64 D Compiler v2.067
Copyright (c) 1999-2014 by Digital Mars written by Walter Bright
```
