### PR TITLE
Build fixes and implement an exit method

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ class MyFS : Operations
 }
 ```
 
-A minimal filesystem implements `Operations.getattr()`, `Operations.readdir()`, `Operations.read()`. See [dfuse/fuse.d](https://github.com/facebook/dfuse/blob/master/dfuse/fuse.d) for implementation specific details.
+A minimal filesystem implements `Operations.getattr()`, `Operations.readdir()`, `Operations.read()`. See [dfuse/fuse.d](https://github.com/facebook/dfuse/blob/master/source/dfuse/fuse.d) for implementation specific details.
 
 To mount a filesystem use a Fuse object and call mount:
 ```D

--- a/dub.json
+++ b/dub.json
@@ -9,12 +9,12 @@
     "configurations": [{
         "name": "dfuse",
         "targetType": "library",
-        "platforms": ["osx"],
-        "libs": ["osxfuse_i32"]
+        "platforms": ["linux"],
+        "libs": ["fuse"]
     }, {
         "name": "dfuse",
         "targetType": "library",
-        "platforms": ["linux"],
-        "libs": ["fuse"]
+        "platforms": ["osx"],
+        "libs": ["osxfuse_i32"]
     }]
 }

--- a/dub.json
+++ b/dub.json
@@ -7,12 +7,12 @@
     "license": "BSL-1.0",
     "dependencies": {},
     "configurations": [{
-        "name": "dfuse",
+        "name": "dfuse-linux",
         "targetType": "library",
         "platforms": ["linux"],
         "libs": ["fuse"]
     }, {
-        "name": "dfuse",
+        "name": "dfuse-osx",
         "targetType": "library",
         "platforms": ["osx"],
         "libs": ["osxfuse_i32"]

--- a/source/c/fuse/common.d
+++ b/source/c/fuse/common.d
@@ -63,7 +63,7 @@ extern (System) {
         /**
          * For future use.
          */
-        uint reserved[23];
+        uint[23] reserved;
     }
 
     static assert(fuse_file_info.sizeof == 64);

--- a/source/dfuse/fuse.d
+++ b/source/dfuse/fuse.d
@@ -17,8 +17,10 @@ import std.array;
 import std.conv;
 import std.stdio;
 import std.string;
+import std.process;
 import errno = core.stdc.errno;
 import core.stdc.string;
+import core.sys.posix.signal;
 
 import c.fuse.fuse;
 
@@ -320,6 +322,7 @@ private:
     bool foreground;
     bool threaded;
     string fsname;
+    int pid;
 
 public:
     this(string fsname)
@@ -381,6 +384,12 @@ public:
             enforce(length == cargs.length);
         }
 
+        this.pid = thisProcessID();
         fuse_main(length, cast(char**) cargs.ptr, &fops, &ops);
+    }
+
+    void exit()
+    {
+        kill(this.pid, SIGINT);
     }
 }


### PR DESCRIPTION
There are several build issue fixes:

- Eliminate warning about an old style array
- Fix incorrect target choice between OSX and Linux

Also implement an exit function to allow the program to exit cleanly.