### PR TITLE
Fix configuration names conflict

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -6,15 +6,6 @@
     "homepage": "http://github.com/facebook/dfuse",
     "license": "BSL-1.0",
     "dependencies": {},
-    "configurations": [{
-        "name": "dfuse",
-        "targetType": "library",
-        "platforms": ["osx"],
-        "libs": ["osxfuse_i32"]
-    }, {
-        "name": "dfuse",
-        "targetType": "library",
-        "platforms": ["linux"],
-        "libs": ["fuse"]
-    }]
+    "libs-linux": ["fuse"],
+    "libs-OSX": ["osxfuse_i32"]
 }


### PR DESCRIPTION
Now it shows a warning: `Warning: Multiple configurations with the name "dfuse" are defined in package "dfuse". This will most likely cause configuration resolution issues.`